### PR TITLE
x86/x86asm: make x86asm.Decode thread-safe

### DIFF
--- a/x86/x86asm/decode.go
+++ b/x86/x86asm/decode.go
@@ -9,7 +9,6 @@ package x86asm
 import (
 	"encoding/binary"
 	"errors"
-	"flag"
 	"fmt"
 	"runtime"
 )
@@ -219,7 +218,6 @@ var (
 
 // decoderCover records coverage information for which parts
 // of the byte code have been executed.
-var useDecoderCover = flag.Bool("x86asm_use_decoder_cover", false, "Whether or not to record coverage information for testing.")
 var decoderCover []bool
 
 // Decode decodes the leading bytes in src as a single instruction.
@@ -463,9 +461,6 @@ ReadPrefixes:
 	// opshift gives the shift to use when saving the next
 	// opcode byte into inst.Opcode.
 	opshift = 24
-	if *useDecoderCover && len(decoderCover) == 0 {
-		decoderCover = make([]bool, len(decoder))
-	}
 
 	// Decode loop, executing decoder program.
 	var oldPC, prevPC int
@@ -477,7 +472,7 @@ Decode:
 			println("run", pc)
 		}
 		x := decoder[pc]
-		if *useDecoderCover {
+		if decoderCover != nil {
 			decoderCover[pc] = true
 		}
 		pc++

--- a/x86/x86asm/decode.go
+++ b/x86/x86asm/decode.go
@@ -9,6 +9,7 @@ package x86asm
 import (
 	"encoding/binary"
 	"errors"
+	"flag"
 	"fmt"
 	"runtime"
 )
@@ -218,7 +219,7 @@ var (
 
 // decoderCover records coverage information for which parts
 // of the byte code have been executed.
-// TODO(rsc): This is for testing. Only use this if a flag is given.
+var useDecoderCover = flag.Bool("x86asm_use_decoder_cover", false, "Whether or not to record coverage information for testing.")
 var decoderCover []bool
 
 // Decode decodes the leading bytes in src as a single instruction.
@@ -462,7 +463,7 @@ ReadPrefixes:
 	// opshift gives the shift to use when saving the next
 	// opcode byte into inst.Opcode.
 	opshift = 24
-	if decoderCover == nil {
+	if *useDecoderCover && len(decoderCover) == 0 {
 		decoderCover = make([]bool, len(decoder))
 	}
 
@@ -476,7 +477,9 @@ Decode:
 			println("run", pc)
 		}
 		x := decoder[pc]
-		decoderCover[pc] = true
+		if *useDecoderCover {
+			decoderCover[pc] = true
+		}
 		pc++
 
 		// Read and decode ModR/M if needed by opcode.

--- a/x86/x86asm/ext_test.go
+++ b/x86/x86asm/ext_test.go
@@ -100,6 +100,8 @@ func testExtDis(
 	generate func(f func([]byte)),
 	allowedMismatch func(text string, size int, inst *Inst, dec ExtInst) bool,
 ) {
+	*useDecoderCover = true
+
 	start := time.Now()
 	ext := &ExtDis{
 		Dec:  make(chan ExtInst),

--- a/x86/x86asm/ext_test.go
+++ b/x86/x86asm/ext_test.go
@@ -100,7 +100,7 @@ func testExtDis(
 	generate func(f func([]byte)),
 	allowedMismatch func(text string, size int, inst *Inst, dec ExtInst) bool,
 ) {
-	*useDecoderCover = true
+	decoderCover = make([]bool, len(decoder))
 
 	start := time.Now()
 	ext := &ExtDis{

--- a/x86/x86asm/ext_test.go
+++ b/x86/x86asm/ext_test.go
@@ -101,6 +101,9 @@ func testExtDis(
 	allowedMismatch func(text string, size int, inst *Inst, dec ExtInst) bool,
 ) {
 	decoderCover = make([]bool, len(decoder))
+	defer func() {
+		decoderCover = nil
+	}()
 
 	start := time.Now()
 	ext := &ExtDis{


### PR DESCRIPTION
Moves initialization of the decoderCover variable from happening
unconditionally to only being initialized by the test code using it so
that it does not cause a data race when not being used and Decode is
called in parallel.

Fixes golang/go#33532