### PR TITLE
arch/x86: Fixed FCLEX/FNCLEX, FCMOVcc, etc... instructions not parse

### DIFF
--- a/x86/x86spec/parse.go
+++ b/x86/x86spec/parse.go
@@ -414,7 +414,7 @@ func parsePage(p pdf.Page, pageNum int) *listing {
 
 	// Table follows; heading is NeoSansIntelMedium and rows are NeoSansIntel.
 	i := 0
-	for i < len(text) && match(text[i], "NeoSansIntelMedium", 9, "") {
+	for i < len(text) && (match(text[i], "NeoSansIntelMedium", 9, "") || match(text[i], "NeoSansIntelMedium", 7.2, "1")) {
 		i++
 	}
 	for i < len(text) && match(text[i], "NeoSansIntel", 9, "") && text[i].S != "NOTES:" {
@@ -819,6 +819,9 @@ func processListing(p *listing, insts *[]*instruction) {
 
 				case "Opcode":
 					inst.opcode = x
+
+				case "1":
+					// pass
 
 				case "Instruction":
 					inst.syntax = x


### PR DESCRIPTION
Fixed FCLEX/FNCLEX, FCMOVcc, FPATAN, INVD, INVLPG, LOCK, OUT, OUTS/OUTSB/OUTSW/OUTSD, PUSH, RCL/RCR/ROL/ROR, RDMSR, SAL/SAR/SHL/SHR, SGDT, and SIDT instructions in Intel Instruction Set Reference golang/go#325383-079US, March 2023 is not parse