### PR TITLE
x86spec: fix header parsing

### DIFF
--- a/x86/x86spec/parse.go
+++ b/x86/x86spec/parse.go
@@ -791,7 +791,7 @@ func processListing(p *listing, insts *[]*instruction) {
 			for i, hdr := range heading {
 				x := row[i]
 				x = strings.Replace(x, "\n", " ", -1)
-				switch strings.TrimSpace(hdr) {
+				switch strings.Replace(strings.TrimSpace(hdr), "\n", " ", -1) {
 				default:
 					wrong = "unexpected header: " + strconv.Quote(hdr)
 					goto BadTable


### PR DESCRIPTION
The existing implementation of the Intel x86 doc parser matches headers by just trimming spaces. However, there are cases, when a header string takes several lines, which breaks current switch case matching, e.g. during the parsing of AMX operations. This commit fixes it by replacing \n with a whitespace in a header string.

For: #61079