### PR TITLE
riscv64: support zihintpause disassembly

### DIFF
--- a/riscv64/riscv64asm/gnu.go
+++ b/riscv64/riscv64asm/gnu.go
@@ -227,7 +227,7 @@ func GNUSyntax(inst Inst) string {
 			inst.Args[1].(MemOrder).String() == "iorw" {
 			args = nil
 		}
-		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		// PAUSE is encoded as a FENCE instruction with pred=W, succ=0.
 		if inst.Args[0].(MemOrder).String() == "w" &&
 			inst.Args[1].(MemOrder).String() == "" {
 			op = "pause"

--- a/riscv64/riscv64asm/gnu.go
+++ b/riscv64/riscv64asm/gnu.go
@@ -227,6 +227,12 @@ func GNUSyntax(inst Inst) string {
 			inst.Args[1].(MemOrder).String() == "iorw" {
 			args = nil
 		}
+		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		if inst.Args[0].(MemOrder).String() == "w" &&
+			inst.Args[1].(MemOrder).String() == "" {
+			op = "pause"
+			args = nil
+		}
 
 	case FSGNJX_D:
 		if inst.Args[1].(Reg) == inst.Args[2].(Reg) {

--- a/riscv64/riscv64asm/inst.go
+++ b/riscv64/riscv64asm/inst.go
@@ -516,16 +516,16 @@ type MemOrder uint8
 
 func (memOrder MemOrder) String() string {
 	var str string
-	if memOrder<<7>>7 == 1 {
+	if memOrder&0b1000 != 0 {
 		str += "i"
 	}
-	if memOrder>>1<<7>>7 == 1 {
+	if memOrder&0b0100 != 0 {
 		str += "o"
 	}
-	if memOrder>>2<<7>>7 == 1 {
+	if memOrder&0b0010 != 0 {
 		str += "r"
 	}
-	if memOrder>>3<<7>>7 == 1 {
+	if memOrder&0b0001 != 0 {
 		str += "w"
 	}
 	return str

--- a/riscv64/riscv64asm/plan9x.go
+++ b/riscv64/riscv64asm/plan9x.go
@@ -181,6 +181,11 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 
 	// Fence instruction in plan9 doesn't have any operands.
 	case FENCE:
+		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		if inst.Args[0].(MemOrder).String() == "w" &&
+			inst.Args[1].(MemOrder).String() == "" {
+			op = "PAUSE"
+		}
 		args = nil
 
 	case FMADD_D, FMADD_H, FMADD_Q, FMADD_S, FMSUB_D, FMSUB_H,

--- a/riscv64/riscv64asm/plan9x.go
+++ b/riscv64/riscv64asm/plan9x.go
@@ -181,7 +181,7 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 
 	// Fence instruction in plan9 doesn't have any operands.
 	case FENCE:
-		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		// PAUSE is encoded as a FENCE instruction with pred=W, succ=0.
 		if inst.Args[0].(MemOrder).String() == "w" &&
 			inst.Args[1].(MemOrder).String() == "" {
 			op = "PAUSE"

--- a/riscv64/riscv64asm/testdata/gnucases.txt
+++ b/riscv64/riscv64asm/testdata/gnucases.txt
@@ -384,6 +384,9 @@ a260|	ld x1,8(x2)
 8624|	fld f9,64(x2)
 3eb0|	fsd f15,32(x2)
 
+# 10.1: "Zihintpause" Extension for Pause Hint, Version 1.0.0
+0f000001|	pause
+
 # 12.3: "Zicond" Extension for Integer Conditional Operations, Version 1.0.0
 b353530e|	czero.eqz x7,x6,x5
 b373530e|	czero.nez x7,x6,x5

--- a/riscv64/riscv64asm/testdata/plan9cases.txt
+++ b/riscv64/riscv64asm/testdata/plan9cases.txt
@@ -337,6 +337,9 @@ b35cbd49|	BEXT X27, X26, X25
 b3115228|	BSET X5, X4, X3
 1393f32b|	BSETI $63, X7, X6
 
+# 10.1: "Zihintpause" Extension for Pause Hint, Version 1.0.0
+0f000001|	PAUSE
+
 # 12.3: "Zicond" Extension for Integer Conditional Operations, Version 1.0.0
 b353530e|	CZEROEQZ X5, X6, X7
 b373530e|	CZERONEZ X5, X6, X7


### PR DESCRIPTION
This patch supports disassembly for Zihintpause, also adds tests.

The predecessor CL is at https://go-review.googlesource.com/c/arch/+/734081