### PR TITLE
riscv64: add support for zbc instructions

### DIFF
--- a/riscv64/riscv64asm/tables.go
+++ b/riscv64/riscv64asm/tables.go
@@ -104,6 +104,9 @@ const (
 	BNE
 	BSET
 	BSETI
+	CLMUL
+	CLMULH
+	CLMULR
 	CLZ
 	CLZW
 	CPOP
@@ -1100,6 +1103,9 @@ var opstr = [...]string{
 	BNE:               "BNE",
 	BSET:              "BSET",
 	BSETI:             "BSETI",
+	CLMUL:             "CLMUL",
+	CLMULH:            "CLMULH",
+	CLMULR:            "CLMULR",
 	CLZ:               "CLZ",
 	CLZW:              "CLZW",
 	CPOP:              "CPOP",
@@ -2191,6 +2197,12 @@ var instFormats = [...]instFormat{
 	{mask: 0xfe00707f, value: 0x28001033, op: BSET, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// BSETI rd, rs1, shamt6
 	{mask: 0xfc00707f, value: 0x28001013, op: BSETI, args: argTypeList{arg_rd, arg_rs1, arg_shamt6}},
+	// CLMUL rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0a001033, op: CLMUL, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// CLMULH rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0a003033, op: CLMULH, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// CLMULR rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0a002033, op: CLMULR, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// CLZ rd, rs1
 	{mask: 0xfff0707f, value: 0x60001013, op: CLZ, args: argTypeList{arg_rd, arg_rs1}},
 	// CLZW rd, rs1

--- a/riscv64/riscv64asm/testdata/gnucases.txt
+++ b/riscv64/riscv64asm/testdata/gnucases.txt
@@ -412,6 +412,11 @@ a260|	ld x1,8(x2)
 b353530e|	czero.eqz x7,x6,x5
 b373530e|	czero.nez x7,x6,x5
 
+# 28.4.3： Zbc: Carry-less multiplication
+b313530a|	clmul	x7,x6,x5
+b333530a|	clmulh	x7,x6,x5
+b323530a|	clmulr	x7,x6,x5
+
 # "V" Standard Extension for Vector Operations, Version 1.0
 
 # 31.6: Configuration Setting Instructions

--- a/riscv64/riscv64asm/testdata/plan9cases.txt
+++ b/riscv64/riscv64asm/testdata/plan9cases.txt
@@ -366,6 +366,11 @@ b3115228|	BSET X5, X4, X3
 b353530e|	CZEROEQZ X5, X6, X7
 b373530e|	CZERONEZ X5, X6, X7
 
+# 28.4.3： Zbc: Carry-less multiplication
+b313530a|	CLMUL	X5, X6, X7
+b333530a|	CLMULH	X5, X6, X7
+b323530a|	CLMULR	X5, X6, X7
+
 # "V" Standard Extension for Vector Operations, Version 1.0
 
 # 31.6: Configuration Setting Instructions

--- a/riscv64/riscv64spec/spec.go
+++ b/riscv64/riscv64spec/spec.go
@@ -34,6 +34,7 @@ var extensions = []string{
 	"rv_v",
 	"rv_zba",
 	"rv_zbb",
+	"rv_zbc",
 	"rv_zbs",
 	"rv_zfh",
 	"rv_zicond",


### PR DESCRIPTION
Add support for the disassembly of Zbc instructions and test cases.