### PR TITLE
x/arch/arm64/arm64asm: add FEAT_MOPS instruction decoding

### DIFF
--- a/arm64/arm64asm/arg.go
+++ b/arm64/arm64asm/arg.go
@@ -489,6 +489,9 @@ const (
 	arg_Xns_mem_wb_imm7_8_signed
 	arg_Xns_mem_wb_imm9_1_signed
 	arg_Xs
+	arg_Xd_mops_mem // [Xd]! destination pointer write-back (MOPS)
+	arg_Xn_mops_wb  // Xn!  count register write-back (MOPS)
+	arg_Xs_mops_wb  // Xs!  source/fill register write-back (MOPS)
 	arg_Xt
 	arg_Xt2
 )

--- a/arm64/arm64asm/decode.go
+++ b/arm64/arm64asm/decode.go
@@ -294,6 +294,15 @@ func decodeArg(aop instArg, x uint32) Arg {
 	case arg_Xs:
 		return X0 + Reg((x>>16)&(1<<5-1))
 
+	case arg_Xd_mops_mem:
+		return MemMOPS{X0 + Reg(x&(1<<5-1))}
+
+	case arg_Xn_mops_wb:
+		return RegWriteBack(X0 + Reg((x>>5)&(1<<5-1)))
+
+	case arg_Xs_mops_wb:
+		return RegWriteBack(X0 + Reg((x>>16)&(1<<5-1)))
+
 	case arg_Xt:
 		return X0 + Reg(x&(1<<5-1))
 

--- a/arm64/arm64asm/inst.go
+++ b/arm64/arm64asm/inst.go
@@ -377,6 +377,26 @@ func (r RegSP) String() string {
 	}
 }
 
+// A RegWriteBack is a register that is written back by the instruction (e.g. MOPS Xn!).
+type RegWriteBack Reg
+
+func (RegWriteBack) isArg() {}
+
+func (r RegWriteBack) String() string {
+	return Reg(r).String() + "!"
+}
+
+// A MemMOPS is a memory operand of the form [Xd]! used by MOPS instructions.
+type MemMOPS struct {
+	Base Reg
+}
+
+func (MemMOPS) isArg() {}
+
+func (m MemMOPS) String() string {
+	return fmt.Sprintf("[%s]!", m.Base.String())
+}
+
 type ImmShift struct {
 	imm   uint16
 	shift uint8

--- a/arm64/arm64asm/tables.go
+++ b/arm64/arm64asm/tables.go
@@ -77,6 +77,9 @@ const (
 	CSINC
 	CSINV
 	CSNEG
+	CPYE
+	CPYM
+	CPYP
 	DC
 	DCPS1
 	DCPS2
@@ -275,6 +278,9 @@ const (
 	SDIV
 	SEV
 	SEVL
+	SETE
+	SETM
+	SETP
 	SHA1C
 	SHA1H
 	SHA1M
@@ -546,6 +552,9 @@ var opstr = [...]string{
 	CSINC:     "CSINC",
 	CSINV:     "CSINV",
 	CSNEG:     "CSNEG",
+	CPYE:      "CPYE",
+	CPYM:      "CPYM",
+	CPYP:      "CPYP",
 	DC:        "DC",
 	DCPS1:     "DCPS1",
 	DCPS2:     "DCPS2",
@@ -744,6 +753,9 @@ var opstr = [...]string{
 	SDIV:      "SDIV",
 	SEV:       "SEV",
 	SEVL:      "SEVL",
+	SETE:      "SETE",
+	SETM:      "SETM",
+	SETP:      "SETP",
 	SHA1C:     "SHA1C",
 	SHA1H:     "SHA1H",
 	SHA1M:     "SHA1M",
@@ -1059,6 +1071,18 @@ var instFormats = [...]instFormat{
 	{0xffe0fc00, 0x9ac02800, ASRV, instArgs{arg_Xd, arg_Xn, arg_Xm}, nil},
 	// AT <at>, <Xt>
 	{0xfff8ff00, 0xd5087800, AT, instArgs{arg_sysop_AT_SYS_CR_system}, at_sys_cr_system_cond},
+	// CPYP [<Xd>]!, [<Xs>]!, <Xn>!
+	{0xffe0fc00, 0x1d000400, CPYP, instArgs{arg_Xd_mops_mem, arg_Xs_mops_wb, arg_Xn_mops_wb}, nil},
+	// CPYM [<Xd>]!, [<Xs>]!, <Xn>!
+	{0xffe0fc00, 0x1d400400, CPYM, instArgs{arg_Xd_mops_mem, arg_Xs_mops_wb, arg_Xn_mops_wb}, nil},
+	// CPYE [<Xd>]!, [<Xs>]!, <Xn>!
+	{0xffe0fc00, 0x1d800400, CPYE, instArgs{arg_Xd_mops_mem, arg_Xs_mops_wb, arg_Xn_mops_wb}, nil},
+	// SETP [<Xd>]!, <Xn>!, <Xs>
+	{0xffe0fc00, 0x1d000c00, SETP, instArgs{arg_Xd_mops_mem, arg_Xn_mops_wb, arg_Xs}, nil},
+	// SETM [<Xd>]!, <Xn>!, <Xs>
+	{0xffe0fc00, 0x1d400c00, SETM, instArgs{arg_Xd_mops_mem, arg_Xn_mops_wb, arg_Xs}, nil},
+	// SETE [<Xd>]!, <Xn>!, <Xs>
+	{0xffe0fc00, 0x1d800c00, SETE, instArgs{arg_Xd_mops_mem, arg_Xn_mops_wb, arg_Xs}, nil},
 	// DC <dc>, <Xt>
 	{0xfff8f000, 0xd5087000, DC, instArgs{arg_sysop_DC_SYS_CR_system}, dc_sys_cr_system_cond},
 	// IC <ic>, {<Xt>}


### PR DESCRIPTION
FEAT_MOPS (Memory Operations) is an ARM extension introduced as optional in Armv8.7 and mandatory from Armv8.8 onwards. It provides three-instruction sequences for hardware-accelerated memory copy and memory set:

  `CPYP/CPYM/CPYE [<Xd>]!, [<Xs>]!, <Xn>!`  - memory copy
  `SETP/SETM/SETE [<Xd>]!, <Xn>!, <Xs>`      - memory set

This change adds decoder support for all six instructions. The operand forms are unique to MOPS: the destination pointer is a memory write-back ([Xd]!), and the count and source registers carry explicit write-back notation (Xn!) to reflect that the CPU updates them in-place during execution. Two new Arg types are introduced to represent these forms: MemMOPS for [Xd]! and RegWriteBack for Xn!.

The per-instruction mask is 0xffe0fc00, which covers the op1[23:22] field that distinguishes the prologue, main, and epilogue variants of each family.

For golang/go#79994