### PR TITLE
riscv64: add disassembler support for Zawrs

### DIFF
--- a/riscv64/riscv64asm/objdumpext_test.go
+++ b/riscv64/riscv64asm/objdumpext_test.go
@@ -289,6 +289,7 @@ func writeELF64(f *os.File, size int) error {
 	strtabsize := len("\x00.text\x00.riscv.attributes\x00.shstrtab\x00")
 	// RISC-V objdump needs the .riscv.attributes section to identify extensions.
 	exts := "rv64i2p0_m2p0_a2p0_f2p0_d2p0_q2p0_c2p0_v1p0_" +
+		"zawrs1p0_" +
 		"zicbom1p0_zicbop1p0_zicboz1p0_zicond1p0_zmmul1p0_" +
 		"zfh1p0_zfhmin1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0_" +
 		"zvkg1p0_zvkned1p0_zvknha1p0_zvknhb1p0_zvksed1p0_zvksh1p0"

--- a/riscv64/riscv64asm/tables.go
+++ b/riscv64/riscv64asm/tables.go
@@ -1025,6 +1025,8 @@ const (
 	VZEXT_VF2
 	VZEXT_VF4
 	VZEXT_VF8
+	WRS_NTO
+	WRS_STO
 	XNOR
 	XOR
 	XORI
@@ -2049,6 +2051,8 @@ var opstr = [...]string{
 	VZEXT_VF2:         "VZEXT.VF2",
 	VZEXT_VF4:         "VZEXT.VF4",
 	VZEXT_VF8:         "VZEXT.VF8",
+	WRS_NTO:           "WRS.NTO",
+	WRS_STO:           "WRS.STO",
 	XNOR:              "XNOR",
 	XOR:               "XOR",
 	XORI:              "XORI",
@@ -4090,6 +4094,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfc0ff07f, value: 0x48022057, op: VZEXT_VF4, args: argTypeList{arg_vm, arg_vs2, arg_vd}},
 	// VZEXT.VF8 vm, vs2, vd
 	{mask: 0xfc0ff07f, value: 0x48012057, op: VZEXT_VF8, args: argTypeList{arg_vm, arg_vs2, arg_vd}},
+	// WRS.NTO
+	{mask: 0xffffffff, value: 0x00d00073, op: WRS_NTO, args: argTypeList{}},
+	// WRS.STO
+	{mask: 0xffffffff, value: 0x01d00073, op: WRS_STO, args: argTypeList{}},
 	// XNOR rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x40004033, op: XNOR, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// XOR rd, rs1, rs2

--- a/riscv64/riscv64asm/testdata/gnucases.txt
+++ b/riscv64/riscv64asm/testdata/gnucases.txt
@@ -417,6 +417,10 @@ a260|	ld x1,8(x2)
 b353530e|	czero.eqz x7,x6,x5
 b373530e|	czero.nez x7,x6,x5
 
+# 15. "Zawrs" Extension for Wait-on-Reservation-Set instructions, Version 1.01
+7300d000|	wrs.nto
+7300d001|	wrs.sto
+
 # 19.6.1: Cache-Block Management Instructions (Zicbom), Version 1.0.0
 0fa01200|	cbo.clean	(x5)
 0fa02200|	cbo.flush	(x5)

--- a/riscv64/riscv64asm/testdata/plan9cases.txt
+++ b/riscv64/riscv64asm/testdata/plan9cases.txt
@@ -370,6 +370,10 @@ b3115228|	BSET X5, X4, X3
 b353530e|	CZEROEQZ X5, X6, X7
 b373530e|	CZERONEZ X5, X6, X7
 
+# 15. "Zawrs" Extension for Wait-on-Reservation-Set instructions, Version 1.01
+7300d000|	WRSNTO
+7300d001|	WRSSTO
+
 # 19.6.1: Cache-Block Management Instructions (Zicbom), Version 1.0.0
 0fa01200|	CBOCLEAN (X5)
 0fa02200|	CBOFLUSH (X5)

--- a/riscv64/riscv64spec/spec.go
+++ b/riscv64/riscv64spec/spec.go
@@ -32,6 +32,7 @@ var extensions = []string{
 	"rv_m",
 	"rv_q",
 	"rv_v",
+	"rv_zawrs",
 	"rv_zba",
 	"rv_zbb",
 	"rv_zbc",


### PR DESCRIPTION
Add disassembly support and tests for Zawrs extension on RISCV64.