### PR TITLE
riscv64: add disassembler support for Zihintntl

### DIFF
--- a/riscv64/riscv64asm/gnu.go
+++ b/riscv64/riscv64asm/gnu.go
@@ -87,6 +87,22 @@ gnuSyntaxSwitch:
 
 	case ADD:
 		if inst.Args[1].(Reg) == X0 {
+			if inst.Args[0].(Reg) == X0 {
+				switch inst.Args[2].(Reg) {
+				case X2:
+					op = "ntl.p1"
+				case X3:
+					op = "ntl.pall"
+				case X4:
+					op = "ntl.s1"
+				case X5:
+					op = "ntl.all"
+				}
+				if op != "add" {
+					args = nil
+					break gnuSyntaxSwitch
+				}
+			}
 			op = "mv"
 			args[1] = args[2]
 			args = args[:len(args)-1]

--- a/riscv64/riscv64asm/objdumpext_test.go
+++ b/riscv64/riscv64asm/objdumpext_test.go
@@ -289,7 +289,7 @@ func writeELF64(f *os.File, size int) error {
 	strtabsize := len("\x00.text\x00.riscv.attributes\x00.shstrtab\x00")
 	// RISC-V objdump needs the .riscv.attributes section to identify extensions.
 	exts := "rv64i2p0_m2p0_a2p0_f2p0_d2p0_q2p0_c2p0_v1p0_" +
-		"zicbom1p0_zicbop1p0_zicboz1p0_zicond1p0_zmmul1p0_" +
+		"zicbom1p0_zicbop1p0_zicboz1p0_zicond1p0_zihintntl1p0_zmmul1p0_" +
 		"zfh1p0_zfhmin1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0_" +
 		"zvkg1p0_zvkned1p0_zvknha1p0_zvknhb1p0_zvksed1p0_zvksh1p0"
 	b := buildRISCVAttributes(exts)

--- a/riscv64/riscv64asm/plan9x.go
+++ b/riscv64/riscv64asm/plan9x.go
@@ -63,6 +63,23 @@ goSyntaxSwitch:
 		// Atomic instructions have special operand order.
 		args[2], args[1] = args[1], args[2]
 
+	case ADD:
+		if inst.Args[0].(Reg) == X0 && inst.Args[1].(Reg) == X0 {
+			switch inst.Args[2].(Reg) {
+			case X2:
+				op = "NTLP1"
+			case X3:
+				op = "NTLPALL"
+			case X4:
+				op = "NTLS1"
+			case X5:
+				op = "NTLALL"
+			default:
+				break goSyntaxSwitch
+			}
+			args = nil
+		}
+
 	case ADDI:
 		if inst.Args[2].(Simm).Imm == 0 {
 			op = "MOV"

--- a/riscv64/riscv64asm/testdata/gnucases.txt
+++ b/riscv64/riscv64asm/testdata/gnucases.txt
@@ -410,6 +410,12 @@ a260|	ld x1,8(x2)
 8624|	fld f9,64(x2)
 3eb0|	fsd f15,32(x2)
 
+# 9. "Zihintntl" Extension for Non-Temporal Locality Hints, Version 1.0
+33002000|	ntl.p1
+33003000|	ntl.pall
+33004000|	ntl.s1
+33005000|	ntl.all
+
 # 10.1: "Zihintpause" Extension for Pause Hint, Version 1.0.0
 0f000001|	pause
 

--- a/riscv64/riscv64asm/testdata/plan9cases.txt
+++ b/riscv64/riscv64asm/testdata/plan9cases.txt
@@ -363,6 +363,12 @@ b35cbd49|	BEXT X27, X26, X25
 b3115228|	BSET X5, X4, X3
 1393f32b|	BSETI $63, X7, X6
 
+# 9. "Zihintntl" Extension for Non-Temporal Locality Hints, Version 1.0
+33002000|	NTLP1
+33003000|	NTLPALL
+33004000|	NTLS1
+33005000|	NTLALL
+
 # 10.1: "Zihintpause" Extension for Pause Hint, Version 1.0.0
 0f000001|	PAUSE
 


### PR DESCRIPTION
Add disassembly support and tests for Zihintntl extension on RISCV64.